### PR TITLE
Update dependencies

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,7 +1,7 @@
 {
   "aliases": {
     "frktest": "lune_packages/.pesde/itsfrank+frktest/0.0.2/frktest/src/",
-    "lune": "~/.lune/.typedefs/0.8.9/",
+    "lune": "~/.lune/.typedefs/0.10.2/",
     "tests": "tests/"
   },
   "languageMode": "strict",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "luau-lsp.require.useOriginalRequireByStringSemantics": true
+  
 }

--- a/pesde.lock
+++ b/pesde.lock
@@ -5,33 +5,33 @@ name = "jiwonz/pathfs"
 version = "0.6.0-rc.8"
 target = "lune"
 
-[graph."corecii/greentea@0.4.11 lune"]
-direct = ["greentea", { name = "corecii/greentea", version = "^0.4.11", index = "default" }, "standard"]
+[graph."abidbmt/greentea@0.5.1 lune"]
+direct = ["greentea", { name = "abidbmt/greentea", version = "^0.5.1", index = "default" }, "standard"]
 
-[graph."corecii/greentea@0.4.11 lune".pkg_ref]
+[graph."abidbmt/greentea@0.5.1 lune".pkg_ref]
 ref_ty = "pesde"
-index_url = "https://github.com/daimond113/pesde-index"
+index_url = "https://github.com/pesde-pkg/index"
 
 [graph."itsfrank/frktest@0.0.2 lune"]
 direct = ["frktest", { name = "itsfrank/frktest", version = "^0.0.2", index = "default" }, "dev"]
 
 [graph."itsfrank/frktest@0.0.2 lune".pkg_ref]
 ref_ty = "pesde"
-index_url = "https://github.com/daimond113/pesde-index"
+index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/luau_disk@0.1.4 luau".pkg_ref]
+[graph."jiwonz/luau_disk@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
 index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/luau_path@0.1.4 luau"]
-direct = ["luau_path", { name = "jiwonz/luau_path", version = "^0.1.4", index = "default", target = "luau" }, "standard"]
+[graph."jiwonz/luau_path@0.2.0 luau"]
+direct = ["luau_path", { name = "jiwonz/luau_path", version = "^0.2.0", index = "default", target = "luau" }, "standard"]
 
-[graph."jiwonz/luau_path@0.1.4 luau".dependencies]
-luau_disk = ["jiwonz/luau_disk@0.1.4 luau", "standard"]
+[graph."jiwonz/luau_path@0.2.0 luau".dependencies]
+luau_disk = ["jiwonz/luau_disk@0.2.0 luau", "standard"]
 
-[graph."jiwonz/luau_path@0.1.4 luau".pkg_ref]
+[graph."jiwonz/luau_path@0.2.0 luau".pkg_ref]
 ref_ty = "pesde"
-index_url = "https://github.com/daimond113/pesde-index"
+index_url = "https://github.com/pesde-pkg/index"
 
-[graph."jiwonz/luau_path@0.1.4 luau".pkg_ref.dependencies]
-luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.1.4", index = "https://github.com/pesde-pkg/index" }, "standard"]
+[graph."jiwonz/luau_path@0.2.0 luau".pkg_ref.dependencies]
+luau_disk = [{ name = "jiwonz/luau_disk", version = "^0.2.0", index = "https://github.com/pesde-pkg/index" }, "standard"]

--- a/pesde.toml
+++ b/pesde.toml
@@ -11,15 +11,15 @@ environment = "lune"
 lib = "src/lib.luau"
 
 [indices]
-default = "https://github.com/daimond113/pesde-index"
+default = "https://github.com/pesde-pkg/index"
 
 [engines]
-lune = "^0.9.4"
-pesde = "^0.7.0-rc.1"
+lune = "^0.10.0"
+pesde = "^0.7.0"
 
 [dependencies]
-luau_path = { name = "jiwonz/luau_path", version = "^0.1.4", target = "luau" }
-greentea = { name = "corecii/greentea", version = "^0.4.11" }
+luau_path = { name = "jiwonz/luau_path", version = "^0.2.0", target = "luau" }
+greentea = { name = "abidbmt/greentea", version = "^0.5.1" }
 
 [dev_dependencies]
 frktest = { name = "itsfrank/frktest", version = "^0.0.2" }


### PR DESCRIPTION
`pathfs` is already compatible with new require by string semantics due to no usage of `init.luau`. Therefore only the dependencies had to be upgraded.